### PR TITLE
fix drunk driver bug

### DIFF
--- a/code/drive_rover.py
+++ b/code/drive_rover.py
@@ -115,14 +115,21 @@ def telemetry(sid, data):
             out_image_string1, out_image_string2 = create_output_images(Rover)
 
             # The action step!  Send commands to the rover!
-            commands = (Rover.throttle, Rover.brake, Rover.steer)
-            send_control(commands, out_image_string1, out_image_string2)
  
+            # Don't send both of these, they both trigger the simulator
+            # to send back new telemetry so we must only send one
+            # back in respose to the current telemetry data.
+
             # If in a state where want to pickup a rock send pickup command
             if Rover.send_pickup and not Rover.picking_up:
                 send_pickup()
                 # Reset Rover flags
                 Rover.send_pickup = False
+            else:
+                # Send commands to the rover!
+                commands = (Rover.throttle, Rover.brake, Rover.steer)
+                send_control(commands, out_image_string1, out_image_string2)
+
         # In case of invalid telemetry, send null commands
         else:
 


### PR DESCRIPTION
This fixes the bug that caused the drive code to build up a backlog of unprocessed telemetry data.  The backlog forced the driving code to run 2 frames behind the simulator for each rock picked up.  After picking up 6 rocks, the driver would be 12 frames behind the simulator, making it trying to drive with data that is up to about 1/2 second old -- creating a drunk driving effect where the rover seems unable to react as quickly as it should.  The more rocks it picks up, the more "drunk" the rover driver becomes. :)

The fix is to not send back both the command data AND the pickup request when a pickup is desired.  Only send one back in response to the telemetry data and no backup is created.
