### PR TITLE
Updating fidelity in create_output_images

### DIFF
--- a/code/supporting_functions.py
+++ b/code/supporting_functions.py
@@ -80,6 +80,7 @@ def create_output_images(Rover):
 
       likely_nav = navigable >= obstacle
       obstacle[likely_nav] = 0
+      navigable[~likely_nav] = 0
       plotmap = np.zeros_like(Rover.worldmap)
       plotmap[:, :, 0] = obstacle
       plotmap[:, :, 2] = navigable


### PR DESCRIPTION
Currently `plotmap` stores all locations that might be navigable, instead of the locations that we are confident are navigable. This change uses the same technique that was used to filter locations that are projected to be obstacles that we have low confidence are in fact obstacles.

I ran into this error when I was trying to debug very low fidelity numbers running in the simulator!